### PR TITLE
Fix build issues on QEMU/ARM builds

### DIFF
--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Aug  6 15:30:07 UTC 2012 - dmueller@suse.com
+
+- fix disablement of make check on QEMU/ARM builds
+
+-------------------------------------------------------------------
 Mon Jun 18 11:50:33 CEST 2012 - aschnell@suse.de
 
 - link agents against y2util and ycpvalues to get proper rpm

--- a/yast2-devtools.spec.in
+++ b/yast2-devtools.spec.in
@@ -46,11 +46,11 @@ autoreconf --force --install
 make
 
 @INSTALL@
-%ifarch %arm
-# disable testsuite on ARM architecture
+%if 0%{?qemu_user_space_build}
+# disable testsuite on QEMU builds, will fail
 cat > "$RPM_BUILD_ROOT/@ydatadir@/devtools/NO_MAKE_CHECK" <<EOF
-Disabling testsuite on ARM architecture, it should be enabled again
-once yast2-core is fixed.
+Disabling testsuite on QEMU builds, as the userspace emulation
+is not complete enough for yast2-core
 EOF
 %endif
 


### PR DESCRIPTION
the old code was entirely broken, ifarch does not work in BuildArch: noarch
packages.

Furthermore, the original ARM issues are fixed on native hardware, however
some issues remain on QEMU builds. so we need the fix for QEMU still.
