### PR TITLE
Added region definition for folding into vim syntax file

### DIFF
--- a/yast2/ycp.vim
+++ b/yast2/ycp.vim
@@ -385,6 +385,10 @@ syn keyword	ycpWidgetSpecial	topMargin
 syn keyword	ycpWidgetSpecial	bottomMargin
 syn keyword	ycpWidgetSpecial	BackgroundPixmap
 
+" folding region definition
+syn region      ycpFold                 start="{" end="}" transparent fold
+syn sync        fromstart
+
 " comment miniles
 if !exists("c_minlines")
   let c_minlines = 15


### PR DESCRIPTION
Folding has to be enabled explicitly (e.g. in .vimrc file using set foldmethod=syntax) so it doesn't break current behavior.
