### PR TITLE
autodocs-ycp.ami - use nobase_ prefix instead of local hooks

### DIFF
--- a/devtools/admin/aminclude/autodocs-ycp.ami
+++ b/devtools/admin/aminclude/autodocs-ycp.ami
@@ -31,7 +31,7 @@ YARD ?= yard
 
 # yard specific clean
 clean-local:
-	rm -rf js css Yast
+	rm -rf js css Yast .yardoc
 
 
 index.html: $(AUTODOCS_YCP) $(AUTODOCS_PM) $(AUTODOCS_RB)


### PR DESCRIPTION
to keep the directory structure
