### PR TITLE
Find API that is unused

### DIFF
--- a/ytools/y2tool/Makefile.am
+++ b/ytools/y2tool/Makefile.am
@@ -5,12 +5,13 @@
 pkgdatadir = @YAST2DEVTOOLS@/bin
 
 pkgdata_SCRIPTS = 				\
+	check_icons				\
 	check-textdomain			\
+	find-unused-published			\
 	get-lib					\
 	pot-spellcheck				\
 	rny2rnc					\
 	showy2log				\
-	tagversion 				\
-	check_icons
+	tagversion
 
 EXTRA_DIST = $(pkgdata_SCRIPTS)

--- a/ytools/y2tool/find-unused-published
+++ b/ytools/y2tool/find-unused-published
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Assist in API cleanup by finding published ("global") functions/variables
+# that are not used by other code.
+#
+# Usage:
+# cd [a clean checkout of all yast repositories]
+# MODULE_RB=yast2/library/network/src/modules/NetworkPopup.rb
+# find-unused-published $MODULE_RB
+
+# $1 YaST Module in Ruby, pathname
+published() {
+    # lines like
+    #    publish :function => :Add, :type => "boolean ()"
+    # transformed to
+    #    Add
+    sed -n -e '/publish/s/[^>]*> :\([^,]*\),.*/\1/;T;p' "$1"
+}
+
+# stdin: one identifier per line
+# $1: namespace
+find_unused() {
+    while read SYM; do
+        grep -E -r "$1(\.|::|->)$SYM" > /dev/null || echo $SYM
+    done
+}
+
+NAMESPACE="${1##*/}"
+NAMESPACE="${NAMESPACE%.rb}"
+published "$1" | find_unused "$NAMESPACE"


### PR DESCRIPTION
Assist in API cleanup by finding published ("global")
functions/variables that are not used by other code.

This is a slightly cleaned up version of what was used in https://github.com/yast/yast-yast2/pull/141
