### PR TITLE
Fix QEMU-ARM build

### DIFF
--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec 13 10:36:59 UTC 2013 - guillaume@opensuse.org
+
+- Fix QEMU-ARM build by adding 
+  %{_datadir}/YaST2/data/devtools/NO_MAKE_CHECK file in file list
+  when built in qemu since no make check are done in this case
+
+-------------------------------------------------------------------
 Wed Dec 11 18:16:18 UTC 2013 - lslezak@suse.cz
 
 - y2autoconf - in perl we need extra backslash escaping

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -156,6 +156,9 @@ EOF
 %dir %{_datadir}/YaST2/data/devtools/bin
 %{_datadir}/YaST2/data/devtools/admin
 %{_datadir}/YaST2/data/devtools/Doxyfile
+%if 0%{?qemu_user_space_build}
+%{_datadir}/YaST2/data/devtools/NO_MAKE_CHECK
+%endif
 # needed for doxygen, not nice
 %{_datadir}/YaST2/data/devtools/footer-notimestamp.html
 %{_datadir}/YaST2/data/devtools/data


### PR DESCRIPTION
Fix QEMU-ARM build by adding %{_datadir}/YaST2/data/devtools/NO_MAKE_CHECK file in file list when built in qemu since no make check are done in this case because QEMU does not support it ATM.
