### PR TITLE
use the first "Version" tag from spec

### DIFF
--- a/build-tools/Makefile.am.toplevel
+++ b/build-tools/Makefile.am.toplevel
@@ -10,7 +10,7 @@
 Y2TOOL = $(Y2DEVTOOLS_PREFIX)/bin/y2tool
 
 RPMNAME 		= $(shell cat $(srcdir)/RPMNAME)
-VERSION			= $(shell grep '^[[:space:]]*Version:' $(srcdir)/package/$(RPMNAME).spec | sed -e 's/Version:[[:space:]]*\([[:print:]]\+\)/\1/')
+VERSION			= $(shell grep -m 1 '^[[:space:]]*Version:' $(srcdir)/package/$(RPMNAME).spec | sed -e 's/Version:[[:space:]]*\([[:print:]]\+\)/\1/')
 SUBDIRS_FILE		= $(shell test -e $(srcdir)/SUBDIRS      && echo SUBDIRS)
 ACINCLUDE_FILE		= $(shell test -e $(srcdir)/acinclude.m4 && echo acinclude.m4)
 

--- a/build-tools/cmake/modules/YastCommon.cmake
+++ b/build-tools/cmake/modules/YastCommon.cmake
@@ -51,7 +51,7 @@ ENDIF (NOT DEFINED RPMNAME)
 
 MESSAGE(STATUS "package name set to '${RPMNAME}'")
 file (GLOB spec_files "package/*.spec")
-execute_process(COMMAND "grep" "^[[:space:]]*Version:" ${spec_files}
+execute_process(COMMAND "grep" "-m" "1" "^[[:space:]]*Version:" ${spec_files}
   COMMAND "sed" "-e" "s/Version:[[:space:]]*\\([[:print:]]\\+\\)/\\1/"
   OUTPUT_VARIABLE VERSION)
 message(STATUS "Version: ${VERSION}")

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -39,7 +39,7 @@ if ($#ARGV >= 0 && ($ARGV[0] eq "-h" || $ARGV[0] eq "--help"))
 $RPMNAME = `cat RPMNAME`;
 chomp $RPMNAME;
 
-$VERSION = `grep '^[[:space:]]*Version:' package/$RPMNAME.spec | sed -e 's/Version:[[:space:]]*\\([[:print:]]\\+\\)/\\1/'`;
+$VERSION = `grep -m 1 '^[[:space:]]*Version:' package/$RPMNAME.spec | sed -e 's/Version:[[:space:]]*\\([[:print:]]\\+\\)/\\1/'`;
 chomp $VERSION;
 
 $MAINTAINER = `cat MAINTAINER`;

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 16 08:51:24 UTC 2013 - lslezak@suse.cz
+
+- use the first "Version" tag from spec when looking for the
+  package version, fixes problem when multiple tags are present
+- 3.1.13
+
+-------------------------------------------------------------------
 Fri Dec 13 10:36:59 UTC 2013 - guillaume@opensuse.org
 
 - Fix QEMU-ARM build by adding 

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.12
+Version:        3.1.13
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 

--- a/ytools/y2tool/tagversion
+++ b/ytools/y2tool/tagversion
@@ -30,7 +30,7 @@ while true; do
 done
 
 p=`cat RPMNAME`
-v=`grep '^[[:space:]]*Version:' package/$p.spec | sed -e 's/Version:[[:space:]]*\([[:print:]]\+\)/\1/' | tr "." "_"`
+v=`grep -m 1 '^[[:space:]]*Version:' package/$p.spec | sed -e 's/Version:[[:space:]]*\([[:print:]]\+\)/\1/' | tr "." "_"`
 if [ -z "$p" -o -z "$v" ]; then
     echo "Cannot find RPMNAME or Version value in package/$p.spec in `pwd`"
     exit 1


### PR DESCRIPTION
when looking for the package version
- fixes problem when multiple tags are present (like in [yast2-theme.spec](https://github.com/yast/yast-theme/blob/master/package/yast2-theme.spec))
- 3.1.13
