### PR TITLE
y2makepot: support for ERB files (*.erb)

### DIFF
--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -22,6 +22,7 @@ function get_domains_and_err()
                                 -o -name "*.c"   \
                                 -o -name "*.cc"  \
                                 -o -name "*.cpp" \
+                                -o -name "*.erb" \
                                 -o -name "*.rb"  `
 
     if test "$?" != "0"; then

--- a/build-tools/scripts/y2makepot
+++ b/build-tools/scripts/y2makepot
@@ -144,7 +144,7 @@ function generate_potfiles()
 	fi
 
         # is it a Ruby file?
-        if [[ "$F" =~ \.rb$ ]]; then
+        if [[ "$F" =~ \.(erb|rb)$ ]]; then
             RUBY_FILES="$RUBY_FILES $F";
         else
             FILES="$FILES $F" ;

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 25 14:15:03 UTC 2014 - lslezak@suse.cz
+
+- y2makepot: added support for extracting translatable strings from
+  ERB files (*.erb)
+- 3.1.17
+
+-------------------------------------------------------------------
 Fri Feb 14 08:59:05 UTC 2014 - jreidinger@suse.com
 
 - return back gettextdomains to allow generating translations

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.16
+Version:        3.1.17
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- 3.1.17

`rxgettext` supports `*.erb` files out of box, the enhancement is trivial
