### PR TITLE
y2makepot: extract translatable strings from control files into glade compatible format

### DIFF
--- a/build-tools/scripts/Makefile.am
+++ b/build-tools/scripts/Makefile.am
@@ -11,4 +11,6 @@ pkgdata_SCRIPTS = 				\
 	y2makepot				\
 	gettextdomains
 
+dist_control_DATA = control_to_glade.xsl
+
 EXTRA_DIST = $(bin_SCRIPTS) $(pkgdata_SCRIPTS)

--- a/build-tools/scripts/control_to_glade.xsl
+++ b/build-tools/scripts/control_to_glade.xsl
@@ -1,0 +1,41 @@
+<!--
+  Extract translatable strings from a Yast XML control file, output them in the
+  format accepted by xgettext (Glade compatible XML)
+-->
+
+<xsl:stylesheet version="1.0"
+  xmlns:n="http://www.suse.com/1.0/yast2ns"
+  xmlns:config="http://www.suse.com/1.0/configns"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:output method="xml" indent="yes"/>
+
+<!-- attribute definition for <interface> element -->
+<xsl:attribute-set name="translatable_label">
+  <xsl:attribute name="name">label</xsl:attribute>
+  <xsl:attribute name="translatable">yes</xsl:attribute>
+</xsl:attribute-set>
+
+<!-- replace <label> by <property>, keep the original value -->
+<xsl:template match="n:label">
+  <xsl:element name="property" use-attribute-sets="translatable_label">
+    <xsl:copy-of select="text()"/>
+  </xsl:element>
+</xsl:template>
+
+<!--
+  replace the root <productDefines> element by <interface>
+  due to namespace it cannot be used literally
+-->
+<xsl:template match="/n:productDefines">
+    <xsl:element name="interface">
+        <xsl:apply-templates select="node()|@*"/>
+    </xsl:element>
+</xsl:template>
+
+<!-- remove the remaining non-matched text -->
+<xsl:template match="text()">
+</xsl:template>
+
+</xsl:stylesheet>
+

--- a/build-tools/scripts/y2makepot
+++ b/build-tools/scripts/y2makepot
@@ -16,6 +16,9 @@
 CWD=`dirname $0`
 . $CWD/gettextdomains
 
+# list of generated files which should be removed at the end
+CLEAN_FILES=""
+
 function gettext_call()
 {
     MODULE=$1
@@ -40,6 +43,12 @@ function gettext_call()
     else
         xgettext_call "$MODULE" "$SOURCE_FILES"
         rxgettext_call "$MODULE" "$SOURCE_RUBY_FILES"
+    fi
+
+    if [ -n "$CLEAN_FILES" ]; then
+        echo "Removing generated files: $CLEAN_FILES"
+        rm -f $CLEAN_FILES
+        CLEAN_FILES=""
     fi
 }
 
@@ -147,7 +156,15 @@ function generate_potfiles()
         if [[ "$F" =~ \.(erb|rb)$ ]]; then
             RUBY_FILES="$RUBY_FILES $F";
         else
-            FILES="$FILES $F" ;
+            if [[ "$F" =~ \.glade$ ]]; then
+                echo "Processing $F file..."
+                GLADE_FILE="$F.translations.glade"
+                xsltproc /usr/share/YaST2/control/control_to_glade.xsl "$F" > "$GLADE_FILE"
+                FILES="$FILES $GLADE_FILE" ;
+                CLEAN_FILES="$CLEAN_FILES $GLADE_FILE" ;
+            else
+                FILES="$FILES $F" ;
+            fi
         fi
     done
 

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jun  5 13:07:52 UTC 2014 - lslezak@suse.cz
+
+- y2makepot: transform control files into glade compatible format
+  so they can be processed by xgettext (the latest xgettext does
+  some format validation before processing) (bnc#881278)
+- 3.1.19
+
+-------------------------------------------------------------------
 Tue Jun  3 15:48:06 UTC 2014 - jreidinger@suse.com
 
 - gettextdomains fix detection of files including somewhere "/*"

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.18
+Version:        3.1.19
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 
@@ -143,6 +143,8 @@ EOF
 %{_datadir}/YaST2/data/devtools/bin/y2makepot
 %{_datadir}/YaST2/data/devtools/bin/gettextdomains
 %{_datadir}/YaST2/data/devtools/bin/ycp_puttext
+%dir %{_datadir}/YaST2/control/
+%{_datadir}/YaST2/control/control_to_glade.xsl
 
 
 %files -n yast2-buildtools


### PR DESCRIPTION
The files then can be processed by `xgettext` (the latest `xgettext` does
some format validation before processing)

See [bnc#881278](https://bugzilla.novell.com/show_bug.cgi?id=881278).
- 3.1.19
