### PR TITLE
gettextdomains: added support for single quotes around textdomain

### DIFF
--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -51,7 +51,7 @@ function get_domains_and_err()
     for F in $TR_FILES $POTFILES; do
         D=`egrep '^[[:space:]]*<?[Tt]extdomain>?' $F | head -n 1 | \
             sed 's/^[[:space:]]*<\?[Tt]extdomain[[:space:]]*[=: \
-                 "(>]*[[:space:]]*\([-_a-zA-Z0-9]*\).*/\1/'`;
+                 '\''"(>]*[[:space:]]*\([-_[:alnum:]]*\).*/\1/'`;
         if [ -z $D ]; then
             ERR="$PWD/$F $ERR" ;
         else

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun  6 14:32:01 CEST 2014 - locilka@suse.com
+
+- gettextdomains: added support for single quotes around
+  textdomain (bnc#881277)
+- 3.1.20
+
+-------------------------------------------------------------------
 Thu Jun  5 13:07:52 UTC 2014 - lslezak@suse.cz
 
 - y2makepot: transform control files into glade compatible format

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.19
+Version:        3.1.20
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- bnc#881277
- there was just support for `textdomain "haha"` but it did not work for valid definition `textdomain 'bimbi'` which was failing for Yast Services Manager
