### PR TITLE
Added Travis script

### DIFF
--- a/travis-tools/README.md
+++ b/travis-tools/README.md
@@ -1,0 +1,15 @@
+## Travis tools
+
+Travis tools are designed to share [Travis CI](https://travis-ci.org)
+scripts.
+
+These scripts are not needed at RPM package build, they can be used from
+`.travis.yml` file.
+
+
+## Travis Documentation
+
+- [General Travis documentation](http://docs.travis-ci.com/user/getting-started/)
+- [Installing extra packages](http://docs.travis-ci.com/user/installing-dependencies/)
+- [Customizing build](http://docs.travis-ci.com/user/customizing-the-build/)
+

--- a/travis-tools/travis_setup.sh
+++ b/travis-tools/travis_setup.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Prepare a Travis node for running Yast build:
+#
+# - import YaST:Head:Travis OBS repository GPG key
+# - add YaST:Head:Travis OBS repository
+# - download/refresh repository metadata
+# - optionally install specified packages
+# - optionally install specified Ruby gems (from rubygems.org)
+#   (Very likely you will need to switch to system Ruby using
+#    "rvm reset" *before* installing gems with this script.)
+#
+
+set -x
+
+# prepare the system for installing additional packages from OBS
+curl http://download.opensuse.org/repositories/YaST:/Head:/Travis/xUbuntu_12.04/Release.key | sudo apt-key add -
+echo "deb http://download.opensuse.org/repositories/YaST:/Head:/Travis/xUbuntu_12.04/ ./" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update -q
+
+while getopts ":p:g:" opt; do
+  case $opt in
+    # install packages
+    p)
+      sudo apt-get install --no-install-recommends $OPTARG
+      ;;
+    # install Ruby gems
+    g)
+      sudo gem install $OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+


### PR DESCRIPTION
The script replaces the common part of `.travis.yml` files by a shared script.

The script should be used like this: https://github.com/yast/yast-dbus-server/compare/Travis?expand=1
