### PR TITLE
Do not hardcode path to rxgettext

### DIFF
--- a/build-tools/scripts/y2makepot
+++ b/build-tools/scripts/y2makepot
@@ -224,7 +224,7 @@ function checkin_potfiles()
 # define global variables
 CHECKIN=1
 XGETTEXT="xgettext"
-RXGETTEXT=/usr/bin/rxgettext
+RXGETTEXT="rxgettext"
 
 SRCDIR="."
 POT_DST=""


### PR DESCRIPTION
Ubuntu by default installs gem binaries to `/usr/local/bin`.
