### PR TITLE
Remove unneeded repositories at Travis

### DIFF
--- a/travis-tools/travis_setup.sh
+++ b/travis-tools/travis_setup.sh
@@ -13,6 +13,11 @@
 
 set -x
 
+# Remove extra repositories to avoid unnecessary downloads at repo refresh,
+# we do not need the latest postgres, mysql, couchdb, rabbitmq, ...
+# The standard Ubuntu repos in /etc/apt/sources.list are kept.
+sudo rm /etc/apt/sources.list.d/*
+
 # prepare the system for installing additional packages from OBS
 curl http://download.opensuse.org/repositories/YaST:/SLE-12:/GA:/Travis/xUbuntu_12.04/Release.key | sudo apt-key add -
 echo "deb http://download.opensuse.org/repositories/YaST:/SLE-12:/GA:/Travis/xUbuntu_12.04/ ./" | sudo tee -a /etc/apt/sources.list


### PR DESCRIPTION
...to save downloads and avoid possible failures.
- Saves about 200kB metadata download (not much, but it's for **every** Yast Travis build, for thousands builds it make sense).
- Can avoid possible failures when a remote repository is down (the less repos to refresh the less fails may happen).
