### PR TITLE
checkall_buildrequires: fix bashism

### DIFF
--- a/ytools/yast2/checkall_buildrequires
+++ b/ytools/yast2/checkall_buildrequires
@@ -8,6 +8,7 @@ MISSING=`rpm -q -- $PKGS | grep "not installed" | sed -e 's/^package //' -e 's/ 
 if [ -z "$MISSING" ]; then
     echo "All required packages are installed"
 else
-    echo -e "MISSING PACKAGES\n" >&2
+    echo "MISSING PACKAGES" >&2
+    echo >&2
     echo "$MISSING"
 fi


### PR DESCRIPTION
'-e' option of 'echo' builtin command may be unsupported in some
POSIX-complete shells.
So replace it with two simple 'echo' commands.
