### PR TITLE
Install "ruby-dev" before installing Ruby gems (SLE12)

### DIFF
--- a/travis-tools/travis_setup.sh
+++ b/travis-tools/travis_setup.sh
@@ -31,6 +31,8 @@ while getopts ":p:g:" opt; do
       ;;
     # install Ruby gems
     g)
+      # install Ruby headers (needed to compile binary gems)
+      sudo apt-get install ruby-dev
       sudo gem install $OPTARG
       ;;
     \?)


### PR DESCRIPTION
- needed to properly compile binary gems

- the overhead for plain Ruby gems is small, it can be installed always
  (the package size is ~1.5MB)

### This is a backport of PR #81 to the SLE12 branch.