### PR TITLE
get GNU Autotools up-to-date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ Makefile.in
 /config.sub
 /configure
 /configure.ac
+/configure.ac~
 /configure.in
+/compile
 /depcomp
 /install-sh
 /libtool

--- a/build-tools/Makefile.am.toplevel
+++ b/build-tools/Makefile.am.toplevel
@@ -72,6 +72,11 @@ endif
 EXTRA_DIST += $(RPMNAME).pc.in
 endif
 
+LIBTOOL_DEPS = @LIBTOOL_DEPS@
+
+libtool: $(LIBTOOL_DEPS)
+	$(SHELL) ./config.status libtool
+
 pot:
 	$(Y2TOOL) y2makepot -s $(srcdir)
 

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -281,9 +281,9 @@ CXXFLAGS="${CXXFLAGS} ${Y2CORE_CFLAGS} -Wall -Wformat=2"
 : ${AGENT_LIBADD:=\'-L$(libdir) -lscr -ly2util -lycpvalues\'}
 AC_SUBST(AGENT_LIBADD)
 
-AC_DISABLE_STATIC
-AC_PROG_LIBTOOL
-AM_PROG_LIBTOOL dnl for libraries
+dnl for libraries
+LT_INIT([disable-static])
+AC_SUBST([LIBTOOL_DEPS])
 
 dnl generate the config header
 AC_CONFIG_HEADERS([config.h]) dnl at the distribution this done

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -87,7 +87,7 @@ $OUTPUT = join ("\n", map { "$_/Makefile" } @SUBDIRS);
 
     # init: common stuff
     '@YAST2-INIT-COMMON@' =>
-"AC_INIT($RPMNAME, $VERSION, http://bugs.opensuse.org/, $RPMNAME)
+"AC_INIT([$RPMNAME],[$VERSION],[http://bugs.opensuse.org/],[$RPMNAME])
 dnl Check for presence of file 'RPMNAME'
 AC_CONFIG_SRCDIR([RPMNAME])
 

--- a/configure.in.in
+++ b/configure.in.in
@@ -18,8 +18,9 @@ CREATE_PKGCONFIG=noarch
 # don't take all the garbage of YaST2-CHECKS-PROGRAM
 # this is anyway necessary only because autoreconf
 # gets confused by Makefile.am in skeletons
-AC_PROG_LIBTOOL
 AC_PROG_CXX
+LT_INIT([disable-static])
+AC_SUBST([LIBTOOL_DEPS])
 
 # perl checks
 AC_CHECK_PROG(PERL, perl, perl, no)

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat May 09 13:14:55 CEST 2015 - besser82@fedoraproject.org
+
+- replace obsolete `AC_PROG_LIBTOOL` with `LT_INIT()`
+- use new `AC_INIT()`-syntax with args in square braces
+- 3.1.32
+
+-------------------------------------------------------------------
 Wed May 06 16:24:52 CEST 2015 - aschnell@suse.de
 
 - require rubygems of default ruby version (bsc#929899)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.31
+Version:        3.1.32
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
* replace obsolete `A[CM]_PROG_LIBTOOL` with `LT_INIT()`
  ```
  Macro: LT_INIT (options)
  AC_PROG_LIBTOOL and AM_PROG_LIBTOOL are deprecated names
  for older versions of this macro.
  ```
  See [GNU Libtool Manual](http://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html).

* use new `AC_INIT()`-syntax with args in square braces
  They are important to ensure that GNU m4 parses the configure.ac file correctly.
  See [GNU Autoconf Manual](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Initializing-configure.html#Initializing-configure).