### PR TITLE
add configure-option '--disable-debug'

### DIFF
--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -35,10 +35,9 @@
     %{_prefix}/bin/y2tool y2automake \
     autoreconf --force --install \
     \
-    export CFLAGS="$RPM_OPT_FLAGS -DNDEBUG" \
-    export CXXFLAGS="$RPM_OPT_FLAGS -DNDEBUG" \
-    \
-    %configure \
+    # '--disable-debug' adds '-DNDEBUG' to C(XX)FLAGS used by %%configure \
+    %configure \\\
+        --disable-debug \
     # V=1: verbose build in case we used AM_SILENT_RULES(yes) \
     # so that RPM_OPT_FLAGS check works \
     make %{?jobs:-j%jobs} V=1

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -181,7 +181,19 @@ AC_SUBST(fillupdir)
     '@YAST2-INIT-PROGRAM@' =>
 'dnl Automake 1.11 enables silent compilation,
 dnl Disable it by "configure --disable-silent-rules" or "make V=1"
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])',
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
+dnl Enable stdlib-debug-macros by default.  Disable debugging-code by
+dnl "configure --disable-debug" or "export C(XX)FLAGS="-DNDEBUG"".
+AC_ARG_ENABLE([debug],
+    AS_HELP_STRING([--disable-debug],
+        [disable stdlib-debug-macros by passing -DNDEBUG to the compiler])
+)
+
+AS_IF([test "x$enable_debug" = "xno"],[
+    CFLAGS="-DNDEBUG ${CFLAGS}"
+    CXXFLAGS="-DNDEBUG ${CXXFLAGS}"
+])',
 
     # init: translation
     '@YAST2-INIT-PO@' =>

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon May 11 17:14:01 CEST 2015 - besser82@fedoraproject.org
+
+- add configure-option '--disable-debug'
+- use '--disable-debug' instead forcing $RPM_OPT_FLAGS into $ENV
+  handling $RPM_OPT_FLAGS is done by %configure-macro anyways
+- 'gettextdomains' is DATA not SCRIPT
+- use 'dist_'-prefix instead of 'EXTRA_DIST'
+- 3.1.33
+
+-------------------------------------------------------------------
 Sat May 09 13:14:55 CEST 2015 - besser82@fedoraproject.org
 
 - replace obsolete `AC_PROG_LIBTOOL` with `LT_INIT()`

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
As the title says.  There is no change in default behaviour. I just added an option to include "-DNDEBUG" by configure-switch in addtion to pass it from $ENV's C(XX)FLAGS.