### PR TITLE
use m4sh-script-dir obsoleting pre-generation of acinclude.m4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,7 @@ Makefile.in
 /package/*.tar.bz2
 /Makefile.am
 /Makefile.am.common
-/acinclude.m4
 /aclocal.m4
-/autodocs-cc-base.ami
-/autodocs-cc-off.ami
-/autodocs-cc.ami
-/autodocs-ycp.ami
 /autom4te.cache/
 /config.guess
 /config.log
@@ -26,11 +21,7 @@ Makefile.in
 /depcomp
 /install-sh
 /libtool
-/libtool.m4
 /ltmain.sh
-/ltoptions.m4
-/ltsugar.m4
-/ltversion.m4
-/lt~obsolete.m4
+/m4
 /missing
 /yast2-devtools.pc

--- a/Makefile.cvs
+++ b/Makefile.cvs
@@ -11,9 +11,10 @@ configure: all
 all:
 	./build-tools/scripts/y2autoconf --bootstrap ./build-tools/
 	./build-tools/scripts/y2automake --bootstrap ./build-tools/
+	#use m4sh-script-dir obsoleting pre-generation of acinclude.m4
 	#ACLOCAL_AMFLAGS is recommended but we have a common Makefile.am
-	cat ./build-tools/aclocal/*.m4 > acinclude.m4
-	autoreconf -v --force --install
+	#cat ./build-tools/aclocal/*.m4 > acinclude.m4
+	autoreconf -v --force --install -Wall
 
 install: configure
 	make

--- a/build-tools/Makefile.am.toplevel
+++ b/build-tools/Makefile.am.toplevel
@@ -12,7 +12,6 @@ Y2TOOL = $(Y2DEVTOOLS_PREFIX)/bin/y2tool
 RPMNAME 		= $(shell cat $(srcdir)/RPMNAME)
 VERSION			= $(shell grep -m 1 '^[[:space:]]*Version:' $(srcdir)/package/$(RPMNAME).spec | sed -e 's/Version:[[:space:]]*\([[:print:]]\+\)/\1/')
 SUBDIRS_FILE		= $(shell test -e $(srcdir)/SUBDIRS      && echo SUBDIRS)
-ACINCLUDE_FILE		= $(shell test -e $(srcdir)/acinclude.m4 && echo acinclude.m4)
 
 COPYRIGHT_files    = COPYING
 doc_DATA = $(COPYRIGHT_files)
@@ -27,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign dist-bzip2 no-dist-gzip
 # where devtools install m4 snippets
 # argh, executed literally
 #ACLOCAL_AMFLAGS = -I $(Y2DEVTOOLS_PREFIX)/share/aclocal
-ACLOCAL_AMFLAGS = -I . -I $(if test -d ./build-tools; then echo ./build-tools; else pkg-config --print-errors --variable=datadir yast2-devtools; fi)/aclocal
+ACLOCAL_AMFLAGS = -I m4 -I . -I $(if test -d ./build-tools; then echo ./build-tools; else pkg-config --print-errors --variable=datadir yast2-devtools; fi)/aclocal
 
 Makefile.am.common: $(DEVTOOLS_DIR)/build-tools/Makefile.am.common
 	cmp -s $< $@ || cp -f $< $@
@@ -46,9 +45,9 @@ POT_DST = $(shell find -type d -name testsuite -prune , \
 	-type f -name "*.pot") 
 
 EXTRA_DIST = \
-	RPMNAME MAINTAINER configure.in.in                      \
-	$(COPYRIGHT_files)                                      \
-	$(SUBDIRS_FILE) $(ACINCLUDE_FILE)			\
+	RPMNAME MAINTAINER configure.in.in			\
+	$(COPYRIGHT_files)					\
+	$(SUBDIRS_FILE)						\
 	$(if $(IS_DEVTOOLS),Makefile.am.common,$(POT_DST))
 
 show-extra-dist:

--- a/build-tools/aminclude/autodocs-cc-off.ami
+++ b/build-tools/aminclude/autodocs-cc-off.ami
@@ -7,6 +7,6 @@
 
 # PARAMETERS: see autodocs-cc-base
 
-include $(top_srcdir)/autodocs-cc-base.ami
+include $(top_srcdir)/m4/autodocs-cc-base.ami
 
 html: index.html

--- a/build-tools/aminclude/autodocs-cc.ami
+++ b/build-tools/aminclude/autodocs-cc.ami
@@ -8,7 +8,7 @@
 # PARAMETERS: (additional to those of autodocs-cc-base)
 #   AUTODOCS_SUBDIR: htmldir will be $(docdir)/$(AUTODOCS_SUBDIR)/autodocs
 
-include $(top_srcdir)/autodocs-cc-base.ami
+include $(top_srcdir)/m4/autodocs-cc-base.ami
 
 htmldir = $(docdir)/$(AUTODOCS_SUBDIR)/autodocs
 html_DATA = $(html_data)

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -88,6 +88,10 @@ $OUTPUT = join ("\n", map { "$_/Makefile" } @SUBDIRS);
     # init: common stuff
     '@YAST2-INIT-COMMON@' =>
 "AC_INIT([$RPMNAME],[$VERSION],[http://bugs.opensuse.org/],[$RPMNAME])
+
+dnl Place m4sh-scripts in m4-dir.
+AC_CONFIG_MACRO_DIR([m4])
+
 dnl Check for presence of file 'RPMNAME'
 AC_CONFIG_SRCDIR([RPMNAME])
 

--- a/build-tools/scripts/y2automake
+++ b/build-tools/scripts/y2automake
@@ -84,9 +84,10 @@ fi
 
 echo "${self}: Copying automakefiles for inclusion"
 AMIS="$common `find $y2adminpath/aminclude -name \*.ami`"
+mkdir -p m4
 for AMI in $AMIS; do
-    cp -f $AMI .
-    chmod u+w ${AMI##*/}
+    cp -f $AMI m4
+    chmod u+w m4/${AMI##*/}
 done
 
 echo "${self}: Generating toplevel Makefile.am"

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sat May 23 11:40:33 CEST 2015 - besser82@fedoraproject.org
+
+- use m4sh-script-dir obsoleting pre-generation of acinclude.m4
+- add '-Wall'-flag to autoreconf in Makefile.cvs
+- updated gitignore
+- 3.1.37
+
+-------------------------------------------------------------------
 Thu May 21 18:16:29 UTC 2015 - lslezak@suse.cz
 
 - y2makepot: do not create confusing _MISSING_TEXTDOMAIN_* files

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.36
+Version:        3.1.37
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
From [GNU libtool manual](http://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html):
```
Macro: LT_OUTPUT

…snip…

Because of these changes, and the runtime version compatibility checks Libtool now
executes, we now advise against including a copy of libtool.m4 (and brethren) in
acinclude.m4.  Instead, you should set your project macro directory with
AC_CONFIG_MACRO_DIRS.  When you libtoolize your project, a copy of the relevant
macro definitions will be placed in your AC_CONFIG_MACRO_DIRS, where aclocal
can reference them directly from aclocal.m4.
```