### PR TITLE
y2makepot: do not create confusing _MISSING_TEXTDOMAIN_* files

### DIFF
--- a/build-tools/scripts/y2makepot
+++ b/build-tools/scripts/y2makepot
@@ -126,8 +126,7 @@ function generate_potfiles()
     # $ERR contains the files without textdomain (see gettextdomains)
     echo
     for F in $ERR; do
-        echo "Warning: empty textdomain in $F" ;
-        echo $F > _MISSING_TEXTDOMAIN_`basename $F` ;
+        echo "** WARNING: Missing textdomain in file $F" 1>&2;
     done
     echo
 

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 21 18:16:29 UTC 2015 - lslezak@suse.cz
+
+- y2makepot: do not create confusing _MISSING_TEXTDOMAIN_* files
+  (they cause for example rubocop check to fail)
+- 3.1.36
+
+-------------------------------------------------------------------
 Thu May 14 08:35:30 UTC 2015 - jreidinger@suse.com
 
 - revert incompatible change for vardir as it break yast2.rpm

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.35
+Version:        3.1.36
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
they cause for example rubocop check to fail

- 3.1.36