### PR TITLE
y2makepot: copy also comments for translators from control.xml

### DIFF
--- a/build-tools/scripts/control_to_glade.xsl
+++ b/build-tools/scripts/control_to_glade.xsl
@@ -23,6 +23,15 @@
   </xsl:element>
 </xsl:template>
 
+<!-- comments for translators -->
+<!-- match a comment immediately preceding a <label>,
+     see http://stackoverflow.com/questions/2613159/xslt-and-xpath-match-preceding-comments -->
+<xsl:template match="comment()[following-sibling::*[1]/self::n:label]">
+  <xsl:copy>
+    <xsl:apply-templates/>
+  </xsl:copy>
+</xsl:template>
+
 <!--
   replace the root <productDefines> element by <interface>
   due to namespace it cannot be used literally

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 14 13:52:04 UTC 2016 - mvidner@suse.com
+
+- y2makepot: copy also comments for translators from control.xml
+  (FATE#317481)
+- 3.1.41
+
+-------------------------------------------------------------------
 Wed Feb 24 09:33:57 UTC 2016 - lslezak@suse.cz
 
 - YaST RPM macros - fix for the previous change: some packages

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.40
+Version:        3.1.41
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
This is needed so that the comments added in https://github.com/yast/skelcd-control-SLES/pull/54 actually reach their audience.
Part of https://trello.com/c/0mOtUy45/467-8-sle-12-sp2-p4-m-feature-317481-add-system-role-capabilities-to-installer