### PR TITLE
more precisely place submit_to line

### DIFF
--- a/ytools/yast2/create_maintenance_branch
+++ b/ytools/yast2/create_maintenance_branch
@@ -54,7 +54,7 @@ def modify_rakefile
     lines[line_index] = new_line
   else # line is not there yet, so place it below require line
     line_index = lines.index {|l| l =~ /require.*yast\/rake/ }
-    lines.insert(lines_index, "\n", new_line)
+    lines.insert(line_index + 1, "\n", new_line)
   end
 
   File.write("Rakefile", lines.join(""))

--- a/ytools/yast2/create_maintenance_branch
+++ b/ytools/yast2/create_maintenance_branch
@@ -53,7 +53,7 @@ def modify_rakefile
   if line_index
     lines[line_index] = new_line
   else # line is not there yet, so place it below require line
-    line_index = lines.index {|l| l =~ /require.*yast\/rake/ }
+    line_index = lines.index {|l| l =~ /^\s*require.*yast\/rake/ }
     lines.insert(line_index + 1, "\n", new_line)
   end
 

--- a/ytools/yast2/create_maintenance_branch
+++ b/ytools/yast2/create_maintenance_branch
@@ -52,8 +52,9 @@ def modify_rakefile
   line_index = lines.index {|l| l =~ /#{submit_to}/ }
   if line_index
     lines[line_index] = new_line
-  else
-    lines.insert(2, new_line, "\n")
+  else # line is not there yet, so place it below require line
+    line_index = lines.index {|l| l =~ /require.*yast\/rake/ }
+    lines.insert(lines_index, "\n", new_line)
   end
 
   File.write("Rakefile", lines.join(""))


### PR DESCRIPTION
There is Rakefiles which have copyright header, in such case, it is
placed after line which require "yast/rake" resulting in exception that
Yast::Tasks do not exists.