### PR TITLE
Fix fillup-templates path

### DIFF
--- a/build-tools/aclocal/y2autoconf.m4
+++ b/build-tools/aclocal/y2autoconf.m4
@@ -80,7 +80,7 @@ AC_SUBST(scrconfdir)
 AC_SUBST(agentdir)
 AC_SUBST(desktopdir)
 
-fillupdir_d="/var/adm/fillup-templates"
+fillupdir_d="/usr/share/fillup-templates"
 AC_ARG_WITH(fillupdir,
     AS_HELP_STRING([--with-fillupdir=DIR],
 		   [where to place fillup templates (default $fillupdir_d.]),

--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -24,7 +24,7 @@
 %yast_docdir %{_docdir}/%{name}
 %yast_logdir %{_localstatedir}/log/YaST2
 %yast_vardir %{_localstatedir}/lib/YaST2
-%yast_fillupdir %{_localstatedir}/adm/fillup-templates
+%yast_fillupdir %{_datadir}/fillup-templates
 
 %yast_execcompdir %{_prefix}/lib/YaST2
 %yast_agentdir %{yast_execcompdir}/servers_non_y2

--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -168,7 +168,7 @@ AC_SUBST(scrconfdir)
 AC_SUBST(agentdir)
 AC_SUBST(desktopdir)
 
-fillupdir_d="/var/adm/fillup-templates"
+fillupdir_d="/usr/share/fillup-templates"
 AC_ARG_WITH(fillupdir,
     AS_HELP_STRING([--with-fillupdir=DIR],
 		   [where to place fillup templates (default $fillupdir_d.]),

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 16:22:16 UTC 2017 - igonzalezsosa@suse.com
+
+- Fix fillup-templates path (bsc#1070408)
+- 4.0.1
+
+-------------------------------------------------------------------
 Tue Oct 10 09:12:46 UTC 2017 - mvidner@suse.com
 
 - Use -Wno-format-nonliteral (bsc#982942)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
The new path for fillup-templates is `/usr/share/fillup-templates`.