### PR TITLE
Do not treat Ruby string interpolations as comments

### DIFF
--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -32,13 +32,13 @@ function get_domains_and_err()
     fi
 
     for F in $SRCFILES; do
-        # strip comments from the files and match [_]_( "..." ), handle Ruby string interpolation
-        # 1. perl: strip one-line-comments
+        # strip comments from the files and match [_]_( "..." )
+        # 1. perl: strip one-line-comments, except ruby "string #{interpolation}"
         # 2. perl: match for _( "...") and __("..." ) (multiline too)
 	# problems left:
 	# - false matches of comments inside strings
 	# - uncaught _( at line beginning
-        MATCH=`perl -n -e 'print "$ARGV: $_" if not /(\/\/|#[^\{])/' $F | \
+        MATCH=`perl -n -e 'print "$ARGV: $_" if not /(^\s*\/\/|^\s*#[^\{])/' $F | \
                perl -n -e 'print "$_" if /[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
         if [ -n "$MATCH" ]; then
             TR_FILES="$F $TR_FILES" ;

--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -32,13 +32,13 @@ function get_domains_and_err()
     fi
 
     for F in $SRCFILES; do
-        # strip comments from the files and match [_]_( "..." )
+        # strip comments from the files and match [_]_( "..." ), handle Ruby string interpolation
         # 1. perl: strip one-line-comments
         # 2. perl: match for _( "...") and __("..." ) (multiline too)
 	# problems left:
 	# - false matches of comments inside strings
 	# - uncaught _( at line beginning
-        MATCH=`perl -n -e 'print "$ARGV: $_" if not /(\/\/|#)/' $F | \
+        MATCH=`perl -n -e 'print "$ARGV: $_" if not /(\/\/|#[^\{])/' $F | \
                perl -n -e 'print "$_" if /[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
         if [ -n "$MATCH" ]; then
             TR_FILES="$F $TR_FILES" ;

--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -35,6 +35,11 @@ function get_domains_and_err()
         # strip comments from the files and match [_]_( "..." )
         # 1. perl: strip one-line-comments, except ruby "string #{interpolation}"
         # 2. perl: match for _( "...") and __("..." ) (multiline too)
+        # NOTE: be less strict here, if e.g. a gettext call is in a trailing comment:
+        # "foo" # _("not translated")
+        # then it will be ignored by the extractor later, we can only get a false
+        # warning about a missing text domain in the file. That's more acceptable
+        # then a completely missing translation because of too strict comment filtering.
 	# problems left:
 	# - false matches of comments inside strings
 	# - uncaught _( at line beginning

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 27 07:52:27 UTC 2018 - lslezak@suse.cz
+
+- Fixed regular expression used for finding translatable messages
+  in the source files (bsc#1082969)
+- 4.0.2
+
+-------------------------------------------------------------------
 Wed Nov 29 16:22:16 UTC 2017 - igonzalezsosa@suse.com
 
 - Fix fillup-templates path (bsc#1070408)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
This is a fix for the script building the POT files.

- The yast-storage-ng code contains a translatable string with interpolation (that's wrong), see [here](https://github.com/yast/yast-storage-ng/blob/e2da188b8d3b39c79028cdd99738b6518ee00da2/src/lib/y2storage/actions_presenter.rb#L107-L110)
- But that text is not found as the script considers the `#{}` interpolation as a comment line (due to `#`) and ignores the line
- Because that file does not contain another translatable string the whole file is ignored
- Because the text is missing in *.pot the `rake check:pot` does not find the issue with the interpolation

Proposed fix

- Do not treat lines with `#{` as comments
- This is not a 100% solution but we would need a full parser instead of "simple" regexps