### PR TITLE
Fixed generating translations from XML files (bsc#1083015)

### DIFF
--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -36,7 +36,8 @@ function get_domains_and_err()
     for F in $SRCFILES; do
         # strip comments from the files and match [_]_( "..." )
         # 1. perl: strip one-line-comments, except ruby "string #{interpolation}"
-        # 2. perl: match for _( "...") and __("..." ) (multiline too)
+        # 2. perl: match for _( "...") and __("..." ) (multiline too),
+        #          or "<label>" used in XML (*.glade) files
         # NOTE: be less strict here, if e.g. a gettext call is in a trailing comment:
         # "foo" # _("not translated")
         # then it will be ignored by the extractor later, we can only get a false

--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -46,7 +46,7 @@ function get_domains_and_err()
 	# - false matches of comments inside strings
 	# - uncaught _( at line beginning
         MATCH=`perl -n -e 'print "$ARGV: $_" if not /(^\s*\/\/|^\s*#[^\{])/' $F | \
-               perl -n -e 'print "$_" if /[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
+               perl -n -e 'print "$_" if /<label>|[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
         if [ -n "$MATCH" ]; then
             TR_FILES="$F $TR_FILES" ;
         fi

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  1 07:41:49 UTC 2018 - lslezak@suse.cz
+
+- Fixed generating translations from XML (*.glade) files
+  (related to bsc#1083015)
+- 4.0.4
+
+-------------------------------------------------------------------
 Tue Feb 27 14:52:17 UTC 2018 - jreidinger@suse.com
 
 - Prevent missing translatable string with missing textdomain by

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- The script skipped all XML files because no gettext call was found
- The XML files do not contain any `_()` or `gettext()` markers, there is `<label>` tag used instead
- With this fix `control.pot` is correctly generated again for `skelcd-control-openSUSE` and others
- 4.0.4

