### PR TITLE
Extract the translatable texts from XSL files (bsc#1083720)

### DIFF
--- a/build-tools/scripts/control_to_glade.xsl
+++ b/build-tools/scripts/control_to_glade.xsl
@@ -42,6 +42,17 @@
     </xsl:element>
 </xsl:template>
 
+<!--
+  Allow processing also the XSL files which contain translations.
+  Handle it like an XML file, just replace the root <xsl:stylesheet> tag
+  by <interface> as expected by xgettext in *.glade files.
+-->
+<xsl:template match="/xsl:stylesheet">
+    <interface>
+        <xsl:apply-templates select="node()|@*"/>
+    </interface>
+</xsl:template>
+
 <!-- remove the remaining non-matched text -->
 <xsl:template match="text()">
 </xsl:template>

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 22 14:28:19 UTC 2018 - lslezak@suse.cz
+
+- Allow extracting the translatable texts alsom from XSL files
+  (bsc#1083720)
+- 4.0.5
+
+-------------------------------------------------------------------
 Thu Mar  1 07:41:49 UTC 2018 - lslezak@suse.cz
 
 - Fixed generating translations from XML (*.glade) files

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1083720
- A XSL file is basically a XML file, we just need to handle the different root element
- 4.0.5