### PR TITLE
Pass absolute paths to "yard"

### DIFF
--- a/build-tools/aminclude/autodocs-ycp.ami
+++ b/build-tools/aminclude/autodocs-ycp.ami
@@ -26,7 +26,7 @@ CLEANFILES = $(nobase_html_DATA) pod2htm*.tmp
 
 AUTODOCS_YCP ?= $(wildcard $(srcdir)/../../src/*.ycp)
 AUTODOCS_PM  ?= $(wildcard $(srcdir)/../../src/*.pm)
-AUTODOCS_RB  ?= $(wildcard $(srcdir)/../../src/modules/*.rb $(srcdir)/../../src/include/*/*.rb)
+AUTODOCS_RB  ?= $(wildcard $(abs_top_srcdir)/src/modules/*.rb $(abs_top_srcdir)/src/include/*/*.rb)
 AUTODOCS_STRIP ?= $(srcdir)/../../src
 
 # yard specific options

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 24 12:34:17 UTC 2018 - lslezak@suse.cz
+
+- Pass absolute paths to "yard", relative paths do not work anymore
+  because of a security update (bsc#1070263, CVE-2017-17042)
+- 3.1.38.1
+
+-------------------------------------------------------------------
 Wed Aug  5 16:57:29 CEST 2015 - shundhammer@suse.de
 
 - reasonable defaults for method and class lengths in rubocop.yml

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        3.1.38
+Version:        3.1.38.1
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- Pass absolute paths to "yard", relative paths do not work anymore because of a recent  security update
- Almost all YaST packages in https://build.suse.de/project/monitor/Devel:YaST:SLE-12-SP1 fail to build in the SLE-12-SP1_Update target
- See https://bugzilla.suse.com/show_bug.cgi?id=1070263
- 3.1.38.1

Note: we stopped generating the autodocs in SP2+ so we need to release the fix only for SP1.

### Change

Originally the relative path was used:

```
yard doc --title "yast2-snapper -- Development Documentation" -o . -m markdown ./../../
src/modules/SnapperDbus.rb ./../../src/modules/Snapper.rb ./../../src/include/snapper/d
ialogs.rb ./../../src/include/snapper/helps.rb ./../../src/include/snapper/wizards.rb
```

But that fails now because the relative prefix is removed:

```
/usr/lib64/ruby/gems/2.1.0/gems/yard-0.8.7.3/lib/yard/core_ext/file.rb:65:in `initialize'
: No such file or directory @ rb_sysopen - src/modules/SnapperDbus.rb (Errno::ENOENT)
```

With the absolute path it works:

```
yard doc --title "yast2-snapper -- Development Documentation" -o . -m markdown /home/abui
ld/rpmbuild/BUILD/yast2-snapper-3.1.10/src/modules/SnapperDbus.rb /home/abuild/rpmbuild/B
UILD/yast2-snapper-3.1.10/src/modules/Snapper.rb /home/abuild/rpmbuild/BUILD/yast2-snappe
r-3.1.10/src/include/snapper/dialogs.rb /home/abuild/rpmbuild/BUILD/yast2-snapper-3.1.10/
src/include/snapper/helps.rb /home/abuild/rpmbuild/BUILD/yast2-snapper-3.1.10/src/include
/snapper/wizards.rb
```

The drawback is that the commadline argument list is a bit longer. But as `getconf ARG_MAX` (max. command line length) returns 2097152 (2MiB) it should be still pretty safe.


## Fixing Specific Packages

This fix expects that the `doc/autodocs` directory is located in the source root. This is the case for most YaST packages but there are two exceptions: `yast2` and `yast2-country`. They use subdirectories so this fix will not work there. I'll fix these 2 packages separately.