### PR TITLE
Merge the yard fix from SP1 to master

### DIFF
--- a/build-tools/aminclude/autodocs-ycp.ami
+++ b/build-tools/aminclude/autodocs-ycp.ami
@@ -26,7 +26,7 @@ CLEANFILES = $(nobase_html_DATA) pod2htm*.tmp
 
 AUTODOCS_YCP ?= $(wildcard $(srcdir)/../../src/*.ycp)
 AUTODOCS_PM  ?= $(wildcard $(srcdir)/../../src/*.pm)
-AUTODOCS_RB  ?= $(wildcard $(srcdir)/../../src/modules/*.rb $(srcdir)/../../src/include/*/*.rb)
+AUTODOCS_RB  ?= $(wildcard $(abs_top_srcdir)/src/modules/*.rb $(abs_top_srcdir)/src/include/*/*.rb)
 AUTODOCS_STRIP ?= $(srcdir)/../../src
 
 # yard specific options

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Jul 25 08:56:11 UTC 2018 - lslezak@suse.cz
+
+- Pass absolute paths to "yard", relative paths do not work anymore
+  because of a security update (bsc#1070263, CVE-2017-17042)
+- We do not auto generate the documentation anymore, but it might
+  be used by some 3rd party packages...
+- 4.1.0
+
+-------------------------------------------------------------------
 Thu Mar 22 14:28:19 UTC 2018 - lslezak@suse.cz
 
 - Allow extracting the translatable texts alsom from XSL files

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.0.5
+Version:        4.1.0
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- We do not auto generate the documentation anymore, we removed that in SLE12-SP2
- But it might be used by some 3rd party packages so it is probably a good idea to fix it in `master` at least