### PR TITLE
Fix up for the icondir path expansion (boo#1109310)

### DIFF
--- a/build-tools/scripts/y2autoconf
+++ b/build-tools/scripts/y2autoconf
@@ -126,6 +126,7 @@ agentdir=${execcompdir}/servers_non_y2
 ydatadir=${yast2dir}/data
 imagedir=${yast2dir}/images
 themedir=${yast2dir}/theme
+icondir=\${prefix}/share/icons
 localedir=${yast2dir}/locale
 clientdir=${yast2dir}/clients
 moduledir=${yast2dir}/modules
@@ -156,6 +157,7 @@ AC_SUBST(mandir)
 
 AC_SUBST(ydatadir)
 AC_SUBST(imagedir)
+AC_SUBST(icondir)
 AC_SUBST(themedir)
 AC_SUBST(localedir)
 AC_SUBST(clientdir)

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 28 09:04:45 UTC 2018 - lslezak@suse.cz
+
+- Fix up for the icondir path expansion (boo#1109310)
+- 4.1.2
+
+-------------------------------------------------------------------
 Tue Nov 27 15:16:44 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 


### PR DESCRIPTION
- Fix for the previous PR #135, installation failed because of unexpanded `@icondir@`:
  `/usr/bin/install -c -p -m 644 icons/hicolor/scalable/apps/yast-audit-laf.svg '@icondir@/hicolor/scalable/apps'`
- 4.1.2