### PR TITLE
Generate metainfo for desktop files

### DIFF
--- a/build-tools/aclocal/y2autoconf.m4
+++ b/build-tools/aclocal/y2autoconf.m4
@@ -44,6 +44,7 @@ agentdir=${execcompdir}/servers_non_y2
 ydatadir=${yast2dir}/data
 imagedir=${yast2dir}/images
 icondir=\${prefix}/share/icons
+metainfodir=\${prefix}/share/metainfo
 themedir=${yast2dir}/theme
 localedir=${yast2dir}/locale
 clientdir=${yast2dir}/clients
@@ -72,6 +73,7 @@ AC_SUBST(mandir)
 AC_SUBST(ydatadir)
 AC_SUBST(imagedir)
 AC_SUBST(icondir)
+AC_SUBST(metainfodir)
 AC_SUBST(themedir)
 AC_SUBST(localedir)
 AC_SUBST(clientdir)

--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -7,6 +7,7 @@
 %yast_ydatadir %{yast_dir}/data
 %yast_imagedir %{yast_dir}/images
 %yast_icondir %{_datadir}/icons
+%yast_metainfodir %{_datadir}/metainfo
 %yast_themedir %{yast_dir}/theme
 %yast_localedir %{yast_dir}/locale
 %yast_clientdir %{yast_dir}/clients
@@ -110,6 +111,7 @@ fi \
         for f in $(%{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -name '*.desktop') ; do \
             d=${f##*/} \
             %suse_update_desktop_file -d ycc_${d%.desktop} ${d%.desktop} \
+            %{yast_ydatadir}/devtools/bin/y2metainfo -f ${f} -l %{license} -o %{yast_metainfodir}/ \
         done \
     %else  # 0%%{?suse_version} \
         %{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -print0 \\\

--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -111,7 +111,7 @@ fi \
         for f in $(%{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -name '*.desktop') ; do \
             d=${f##*/} \
             %suse_update_desktop_file -d ycc_${d%.desktop} ${d%.desktop} \
-            %{yast_ydatadir}/devtools/bin/y2metainfo -f ${f} -l %{license} -o %{yast_metainfodir}/ \
+            %{yast_ydatadir}/devtools/bin/y2metainfo -f ${f} -l "%{license}" -o %{yast_metainfodir}/ \
         done \
     %else  # 0%%{?suse_version} \
         %{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -print0 \\\

--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -103,6 +103,12 @@ fi \
       fi \
     %endif
 
+%yast_metainfo \
+    \
+    for f in $(%{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -name '*.desktop') ; do \
+        %{yast_ydatadir}/devtools/bin/y2metainfo -f ${f} -l "%{license}" -o %{buildroot}/%{yast_metainfodir}/ \
+    done
+
 %yast_desktop_files \
     \
     # on SUSE we use %%suse_update_desktop_file \
@@ -111,7 +117,6 @@ fi \
         for f in $(%{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -name '*.desktop') ; do \
             d=${f##*/} \
             %suse_update_desktop_file -d ycc_${d%.desktop} ${d%.desktop} \
-            %{yast_ydatadir}/devtools/bin/y2metainfo -f ${f} -l "%{license}" -o %{yast_metainfodir}/ \
         done \
     %else  # 0%%{?suse_version} \
         %{_bindir}/find %{buildroot}/%{yast_desktopdir}/ -print0 \\\

--- a/build-tools/scripts/Makefile.am
+++ b/build-tools/scripts/Makefile.am
@@ -8,7 +8,8 @@ dist_bin_SCRIPTS = y2tool
 dist_pkgdata_SCRIPTS = 				\
 	y2autoconf 				\
 	y2automake 				\
-	y2makepot
+	y2makepot				\
+	y2metainfo
 
 # This file should have 0644 perms, since it gets
 # sourced by 'check-textdomain' and 'y2makepot'.

--- a/build-tools/scripts/y2metainfo
+++ b/build-tools/scripts/y2metainfo
@@ -43,8 +43,16 @@ def metainfo_gen(desktop, license)
   base.add_element("id").add_text(File.basename(desktop, ".desktop"))
   # Exectutes based on id of desktop file https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
   base.add_element("launchable", "type" => "desktop-id").add_text(File.basename(desktop))
-  base.add_element("_name").add_text(data["Name"])
-  base.add_element("_summary").add_text(data["GenericName"])
+  data.select{ |x| x.start_with?("Name") }.each do |key, value|
+    name = base.add_element("name").add_text(value)
+    lang = (/(?<=\[).*(?=\])/).match(key)
+    name.add_attribute("xml:lang", lang) if lang
+  end
+  data.select{ |x| x.start_with?("GenericName") }.each do |key, value|
+    name = base.add_element("summary").add_text(value)
+    lang = (/(?<=\[).*(?=\])/).match(key)
+    name.add_attribute("xml:lang", lang) if lang
+  end
   cat = base.add_element("categories")
   data["Categories"].split(";").each do |category|
     cat.add_element("category").add_text(category)

--- a/build-tools/scripts/y2metainfo
+++ b/build-tools/scripts/y2metainfo
@@ -1,13 +1,20 @@
 #!/usr/bin/env ruby
-require 'builder'
-require 'optparse'
-require 'inifile'
+#
+# y2metainfo - Automagically generate appstream data for YaST modules based on their desktop files
+#
+# Author: Stasiek Michalski <hellcp@opensuse.org>
+# Copyright 2019
+#
+
+require "rexml/document"
+require "optparse"
+require "inifile"
 
 options = {}
 
 OptionParser.new do |parser|
   parser.banner = "Usage: y2metainfo [options]"
-  parser.on("-h", "--help", "Show this help message") do ||
+  parser.on("-h", "--help", "Show this help message") do
     puts parser
   end
   parser.on("-f", "--file FILEPATH", "The desktop file of the module") do |v|
@@ -22,37 +29,38 @@ OptionParser.new do |parser|
 end.parse!
 
 def metainfo_gen(desktop, license)
-  output = ''
-  xml = ::Builder::XmlMarkup.new(:target => output, :indent => 2)
-  file = IniFile.load(desktop, :comment => nil)
+  output = ""
+  xml = REXML::Document.new
+  file = IniFile.load(desktop, comment: nil)
   data = file["Desktop Entry"]
-  xml.instruct!
-  xml.component('type' => 'addon','xmlns' => 'https://specifications.freedesktop.org/metainfo/1.0') do
-    xml.id File.basename(desktop)
-    xml.launchable(File.basename(desktop), 'type' => 'desktop-id')
-    xml._name data["Name"]
-    xml._summary data["GenericName"]
-    xml.extends 'YaST2.desktop'
-    xml.metadata_license 'CC0-1.0'
-    xml.project_license license if license
-    categories = data["Categories"].split(';')
-    xml.categories do
-      categories.each do |category|
-        xml.category category
-      end
-    end
-    xml.url('https://yast.opensuse.org', 'type' => 'homepage')
-    xml.url('https://bugzilla.opensuse.org', 'type' => 'bugtracker')
-    xml.developer_name 'YaST Team'
+
+  xml << REXML::XMLDecl.new("1.0", "UTF-8")
+  base = xml.add_element("component", "type" => "addon", "xmlns" => "https://specifications.freedesktop.org/metainfo/1.0")
+  base.add_element("id").add_text(File.basename(desktop, ".desktop"))
+  base.add_element("launchable", "type" => "desktop-id").add_text(File.basename(desktop))
+  base.add_element("_name").add_text(data["Name"])
+  base.add_element("_summary").add_text(data["GenericName"])
+  base.add_element("entends").add_text("org.openSUSE.YaST")
+  base.add_element("metadata_license").add_text("CC0-1.0")
+  base.add_element("project_license").add_text(license) if license
+  cat = base.add_element("categories")
+  data["Categories"].split(";").each do |category|
+    cat.add_element("category").add_text(category)
   end
+  base.add_element("url", "type" => "homepage").add_text("https://yast.opensuse.org")
+  base.add_element("url", "type" => "bugtracker").add_text("https://bugzilla.opensuse.org")
+  base.add_element("developer_name").add_text("YaST Team")
+  base.add_element("update_contact").add_text("yast-devel@opensuse.org")
+
+  formatter = REXML::Formatters::Pretty.new(2)
+  formatter.compact = true
+  formatter.write(xml, output)
   output
 end
 
 if options[:output]
   filename = options[:output] + File.basename(options[:file], ".desktop") + ".metainfo.xml"
-  out_file = File.new(filename, "w")
-  out_file.puts(metainfo_gen(options[:file], options[:license]))
-  out_file.close
+  File.write(filename, metainfo_gen(options[:file], options[:license]))
 else
   puts metainfo_gen(options[:file], options[:license])
 end

--- a/build-tools/scripts/y2metainfo
+++ b/build-tools/scripts/y2metainfo
@@ -40,7 +40,7 @@ def metainfo_gen(desktop, license)
   base.add_element("launchable", "type" => "desktop-id").add_text(File.basename(desktop))
   base.add_element("_name").add_text(data["Name"])
   base.add_element("_summary").add_text(data["GenericName"])
-  base.add_element("entends").add_text("org.openSUSE.YaST")
+  base.add_element("extends").add_text("org.openSUSE.YaST")
   base.add_element("metadata_license").add_text("CC0-1.0")
   base.add_element("project_license").add_text(license) if license
   cat = base.add_element("categories")

--- a/build-tools/scripts/y2metainfo
+++ b/build-tools/scripts/y2metainfo
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 #
-# y2metainfo - Automagically generate appstream data for YaST modules based on their desktop files
+# y2metainfo - Automatically generate appstream data for YaST modules based on
+# their desktop files
+# Based on upstream appstream spec:
+# https://www.freedesktop.org/wiki/Distributions/AppStream/
+#
+# Fixes: https://features.opensuse.org/319035
 #
 # Author: Stasiek Michalski <hellcp@opensuse.org>
 # Copyright 2019
@@ -8,7 +13,6 @@
 
 require "rexml/document"
 require "optparse"
-require "inifile"
 
 options = {}
 
@@ -31,25 +35,27 @@ end.parse!
 def metainfo_gen(desktop, license)
   output = ""
   xml = REXML::Document.new
-  file = IniFile.load(desktop, comment: nil)
-  data = file["Desktop Entry"]
-
   xml << REXML::XMLDecl.new("1.0", "UTF-8")
   base = xml.add_element("component", "type" => "addon", "xmlns" => "https://specifications.freedesktop.org/metainfo/1.0")
+
+  file = File.open(desktop).read
+  data = Hash[file.scan(/(.*)?=\s*?(.*)/).map { |k,v| [k.strip, v.strip] }]
   base.add_element("id").add_text(File.basename(desktop, ".desktop"))
+  # Exectutes based on id of desktop file https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
   base.add_element("launchable", "type" => "desktop-id").add_text(File.basename(desktop))
   base.add_element("_name").add_text(data["Name"])
   base.add_element("_summary").add_text(data["GenericName"])
-  base.add_element("extends").add_text("org.openSUSE.YaST")
-  base.add_element("metadata_license").add_text("CC0-1.0")
-  base.add_element("project_license").add_text(license) if license
   cat = base.add_element("categories")
   data["Categories"].split(";").each do |category|
     cat.add_element("category").add_text(category)
   end
+  if license
+    base.add_element("metadata_license").add_text(license)
+    base.add_element("project_license").add_text(license)
+  end
+  base.add_element("extends").add_text("org.openSUSE.YaST")
   base.add_element("url", "type" => "homepage").add_text("https://yast.opensuse.org")
   base.add_element("url", "type" => "bugtracker").add_text("https://bugzilla.opensuse.org")
-  base.add_element("developer_name").add_text("YaST Team")
   base.add_element("update_contact").add_text("yast-devel@opensuse.org")
 
   formatter = REXML::Formatters::Pretty.new(2)
@@ -58,9 +64,10 @@ def metainfo_gen(desktop, license)
   output
 end
 
-if options[:output]
+result = metainfo_gen(options[:file], options[:license])
+if options[:output] && options[:file]
   filename = options[:output] + File.basename(options[:file], ".desktop") + ".metainfo.xml"
-  File.write(filename, metainfo_gen(options[:file], options[:license]))
-else
-  puts metainfo_gen(options[:file], options[:license])
+  File.write(filename, result)
+elsif options[:file]
+  puts result
 end

--- a/build-tools/scripts/y2metainfo
+++ b/build-tools/scripts/y2metainfo
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+require 'builder'
+require 'optparse'
+require 'inifile'
+
+options = {}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: y2metainfo [options]"
+  parser.on("-h", "--help", "Show this help message") do ||
+    puts parser
+  end
+  parser.on("-f", "--file FILEPATH", "The desktop file of the module") do |v|
+    options[:file] = v
+  end
+  parser.on("-l", "--license LICENSE", "The license of the module") do |v|
+    options[:license] = v
+  end
+  parser.on("-o", "--output DIRECTORY", "The output directory") do |v|
+    options[:output] = v
+  end
+end.parse!
+
+def metainfo_gen(desktop, license)
+  output = ''
+  xml = ::Builder::XmlMarkup.new(:target => output, :indent => 2)
+  file = IniFile.load(desktop, :comment => nil)
+  data = file["Desktop Entry"]
+  xml.instruct!
+  xml.component('type' => 'addon','xmlns' => 'https://specifications.freedesktop.org/metainfo/1.0') do
+    xml.id File.basename(desktop)
+    xml.launchable(File.basename(desktop), 'type' => 'desktop-id')
+    xml._name data["Name"]
+    xml._summary data["GenericName"]
+    xml.extends 'YaST2.desktop'
+    xml.metadata_license 'CC0-1.0'
+    xml.project_license license if license
+    categories = data["Categories"].split(';')
+    xml.categories do
+      categories.each do |category|
+        xml.category category
+      end
+    end
+    xml.url('https://yast.opensuse.org', 'type' => 'homepage')
+    xml.url('https://bugzilla.opensuse.org', 'type' => 'bugtracker')
+    xml.developer_name 'YaST Team'
+  end
+  output
+end
+
+if options[:output]
+  filename = options[:output] + File.basename(options[:file], ".desktop") + ".metainfo.xml"
+  out_file = File.new(filename, "w")
+  out_file.puts(metainfo_gen(options[:file], options[:license]))
+  out_file.close
+else
+  puts metainfo_gen(options[:file], options[:license])
+end

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 20 15:28:02 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
+
+- Generate metainfo appstream for desktop files (fate#319035)
+- 4.2.1
+
+-------------------------------------------------------------------
 Thu Apr 25 15:56:13 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Check if directory exists before updating desktop files (boo#1133433)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            http://github.com/yast/yast-devtools
 
@@ -54,6 +54,8 @@ Requires:       autoconf
 Requires:       automake
 Requires:       gettext-tools
 Requires:       pkgconfig >= 0.16
+Requires:       rubygem(builder)
+Requires:       rubygem(inifile)
 
 %if 0%{?suse_version} <= 1230
 # extra package for yard Markdown formatting in openSUSE <= 12.3
@@ -168,6 +170,7 @@ EOF
 %{_datadir}/YaST2/data/devtools/data/YaST2.dict.txt
 %{_datadir}/YaST2/data/devtools/bin/y2autoconf
 %{_datadir}/YaST2/data/devtools/bin/y2automake
+%{_datadir}/YaST2/data/devtools/bin/y2metainfo
 %license COPYING
 
 

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -54,7 +54,6 @@ Requires:       autoconf
 Requires:       automake
 Requires:       gettext-tools
 Requires:       pkgconfig >= 0.16
-Requires:       rubygem(builder)
 Requires:       rubygem(inifile)
 
 %if 0%{?suse_version} <= 1230

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -54,7 +54,6 @@ Requires:       autoconf
 Requires:       automake
 Requires:       gettext-tools
 Requires:       pkgconfig >= 0.16
-Requires:       rubygem(inifile)
 
 %if 0%{?suse_version} <= 1230
 # extra package for yard Markdown formatting in openSUSE <= 12.3


### PR DESCRIPTION
https://features.opensuse.org/319035 "Make YaST (incl. modules) available in GNOME Software"