### PR TITLE
Fixed syntax error in the RPM macros

### DIFF
--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -143,6 +143,6 @@ fi \
         echo "Cannot install the package, no configure.{ac|in}.in or Rakefile found" 1>&2 \
         exit 1 \
     fi \
-    if [ -d "%{buildroot}/%{yast_desktopdir}"]; then \
+    if [ -d "%{buildroot}/%{yast_desktopdir}" ]; then \
       %yast_desktop_files \
     fi \

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jul 17 07:25:46 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed syntax error in the RPM macros causing
+  "line 53: [: missing `]'" error during package build
+- Related to the desktop file changes (boo#1084864)
+- 4.2.5
+
+-------------------------------------------------------------------
 Tue Jun 25 11:43:00 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow smooth adaptation of newer rubocop by adding defaults for

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Url:            https://github.com/yast/yast-devtools
 Summary:        YaST2 - Development Tools


### PR DESCRIPTION
- Fixed syntax error in the RPM macros causing ``line 53: [: missing `]'`` error during package build
- Found accidentally in this [Travis log](https://travis-ci.org/yast/yast-country/builds/546694483#L1187)
- Related to the desktop file changes ([boo#1084864](https://bugzilla.opensuse.org/show_bug.cgi?id=1084864))
- 4.2.5