### PR TITLE
Set %yast_icondir to /usr/share/icons/hicolor (bsc#1186066)

### DIFF
--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -6,7 +6,7 @@
 
 %yast_ydatadir %{yast_dir}/data
 %yast_imagedir %{yast_dir}/images
-%yast_icondir %{_datadir}/icons
+%yast_icondir %{_datadir}/icons/hicolor
 %yast_metainfodir %{_datadir}/metainfo
 %yast_themedir %{yast_dir}/theme
 %yast_localedir %{yast_dir}/locale

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri May 14 16:33:01 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Change the %yast_icondir RPM macro from /usr/share/icons to
+  /usr/share/icons/hicolor, /usr/share/icons is owned by
+  "filesystem" package with different permissions (bsc#1186066)
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr  7 19:37:37 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop installing COPYING as documentation - it is already installed

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1186066
- The YaST packages should not own the `/usr/share/icons/` directory
- That is owned by the `filesystem` package but with different permissions and that causes troubles
- The `hicolor` subdirectory is owned by `hicolor-icon-theme` so it is not the ideal solution (it just moves the problem
  one level down), but as that directory is owned by more than 230 other packages changing that would require a lot of work...
- All YaST packages have icons only in the `hicolor` subdir so it should not cause problems
- The solution has been discussed with @DimStar77 on IRC