### PR TITLE
Install yast macros to %{_rpmmacrodir}

### DIFF
--- a/build-tools/rpm/Makefile.am
+++ b/build-tools/rpm/Makefile.am
@@ -2,7 +2,7 @@
 # Makefile.am for devtools/devtools/rpm
 #
 
-rpmdir = /etc/rpm
+rpmdir = /usr/lib/rpm/macros.d
 
 dist_rpm_DATA =	macros.yast
 

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug  4 09:54:08 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Move YaST macros to %{_rpmmacrodir} instead of %{_sysconfdir}
+  (bsc#1189044).
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr  7 19:37:37 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop installing COPYING as documentation - it is already installed

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later
@@ -134,7 +134,7 @@ EOF
 %{_datadir}/YaST2/control/control_to_glade.xsl
 
 %files -n yast2-buildtools
-%{_sysconfdir}/rpm/macros.yast
+%{_rpmmacrodir}/macros.yast
 %{_bindir}/y2tool
 %{_datadir}/aclocal/*.m4
 %{_datadir}/pkgconfig/yast2-devtools.pc


### PR DESCRIPTION
## Problem

The package yast2-buildtools installs the YaST macros in **/etc/rpm/macros.yast**

As reported in the bug RPM packages though are supposed to install their macro files to **/usr/lib/rpm/macros.d** (use the variable %{_rpmmacrodir})

- https://bugzilla.suse.com/show_bug.cgi?id=1189044

## Solution

Apply suggested change

