### PR TITLE
Fixed generating POT files from XML (bsc#1197965)

### DIFF
--- a/build-tools/scripts/control_to_glade.xsl
+++ b/build-tools/scripts/control_to_glade.xsl
@@ -16,10 +16,52 @@
   <xsl:attribute name="translatable">yes</xsl:attribute>
 </xsl:attribute-set>
 
-<!-- replace <label> by <property>, keep the original value -->
+<!--
+  Template for trimming leading and trailing white space (spaces and new lines)
+  from a string.
+
+  Notes:
+    - The XSL already contains built-in function "normalize-space()", unfortunately
+      this also trims extra white space *inside* the string which we do not want
+      in this case. :-(
+    - Inspired by https://stackoverflow.com/a/30463195
+    - In XSL "substring()" function the index starts from 1!!
+-->
+<xsl:template name="trim">
+  <xsl:param name="str"/>
+
+  <xsl:choose>
+    <!-- starts with a new line or space? -->
+    <xsl:when test="string-length($str) &gt; 0 and (substring($str, 1, 1) = '&#x0a;' or substring($str, 1, 1) = ' ')">
+      <!-- recursively call self with the string without the first character -->
+      <xsl:call-template name="trim">
+        <xsl:with-param name="str">
+          <xsl:value-of select="substring($str, 2)"/>
+        </xsl:with-param>
+      </xsl:call-template>
+    </xsl:when>
+    <!-- ends with a new line or space? -->
+    <xsl:when test="string-length($str) &gt; 0 and (substring($str, string-length($str)) = '&#x0a;' or substring($str, string-length($str)) = ' ')">
+      <!-- recursively call self with the string without the last character -->
+      <xsl:call-template name="trim">
+        <xsl:with-param name="str">
+          <xsl:value-of select="substring($str, 1, string-length($str) - 1)"/>
+        </xsl:with-param>
+      </xsl:call-template>
+    </xsl:when>
+    <!-- otherwise just return the original string -->
+    <xsl:otherwise>
+      <xsl:value-of select="$str"/>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<!-- replace <label> by <property>, trim the leading and trailing white space from the value -->
 <xsl:template match="n:label">
   <xsl:element name="property" use-attribute-sets="translatable_label">
-    <xsl:copy-of select="text()"/>
+    <xsl:call-template name="trim">
+      <xsl:with-param name="str" select="text()"/>
+    </xsl:call-template>
   </xsl:element>
 </xsl:template>
 

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 12 13:20:40 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed generating POT files from XML, trim the leading and
+  trailing white space to be compatible with the Ruby code
+  (bsc#1197965)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1197965

The translatable messages from XML contain surrounding white space in the generated POT file. However, when YaST parses the XML it [trims the white space away](https://github.com/yast/yast-yast2/blob/b3cc5ae199cdf74fca0f4567bc08f4cebc722773/library/xml/src/modules/XML.rb#L256). That might cause a mismatch between the original text and the translations, the result is that these messages are displayed untranslated.

## Solution

Trim the leading and trailing white space from the messages when generating the POT files. Then the POT messages will match what YaST will read from the XML file.

## Testing

For testing I used the [yast-firstboot/firstboot.xml](https://github.com/yast/yast-firstboot/blob/master/wsl/firstboot.xml) file which contains this snippet with a translatable text:

```xml
<congratulate><label>
    &lt;p&gt;Configuration of &amp;product; for WSL is complete!&lt;/p&gt;
    &lt;p&gt;Call yast2 any time to tweak it.&lt;/p&gt;
    &lt;p&gt;Have a lot of fun...&lt;/p&gt;
</label></congratulate>
```

If you parse that with YaST you will get this text:

```
irb(main):004:0> Yast::XML.XMLToYCPFile("wsl/firstboot.xml")["texts"]["congratulate"]["label"]
=> "<p>Configuration of &product; for WSL is complete!</p>\n            <p>Call yast2 any time to tweak it.</p>\n            <p>Have a lot of fun...</p>"
```

But originally this text was extracted to the POT file like this:

```po
#: wsl/firstboot.glade.translations.glade:25
msgid ""
"\n"
"            <p>Configuration of &product; for WSL is complete!</p>\n"
"            <p>Call yast2 any time to tweak it.</p>\n"
"            <p>Have a lot of fun...</p>\n"
"        "
```

Notice the white space at the beginning and at the end of the text. This causes mismatch resulting in missing translation for it.

With the fix the extracted text looks like this:

```po
#: wsl/firstboot.glade.translations.glade:25
msgid ""
"<p>Configuration of &product; for WSL is complete!</p>\n"
"            <p>Call yast2 any time to tweak it.</p>\n"
"            <p>Have a lot of fun...</p>"
```

That exactly matches the text read by the Ruby code.