### PR TITLE
Trim also the tabs (bsc#1197965)

### DIFF
--- a/build-tools/scripts/control_to_glade.xsl
+++ b/build-tools/scripts/control_to_glade.xsl
@@ -31,8 +31,8 @@
   <xsl:param name="str"/>
 
   <xsl:choose>
-    <!-- starts with a new line or space? -->
-    <xsl:when test="string-length($str) &gt; 0 and (substring($str, 1, 1) = '&#x0a;' or substring($str, 1, 1) = ' ')">
+    <!-- starts with a new line, tab or space? -->
+    <xsl:when test="string-length($str) &gt; 0 and (substring($str, 1, 1) = '&#x0a;' or substring($str, 1, 1) = '&#x09;' or substring($str, 1, 1) = ' ')">
       <!-- recursively call self with the string without the first character -->
       <xsl:call-template name="trim">
         <xsl:with-param name="str">
@@ -40,8 +40,8 @@
         </xsl:with-param>
       </xsl:call-template>
     </xsl:when>
-    <!-- ends with a new line or space? -->
-    <xsl:when test="string-length($str) &gt; 0 and (substring($str, string-length($str)) = '&#x0a;' or substring($str, string-length($str)) = ' ')">
+    <!-- ends with a new line, tab or space? -->
+    <xsl:when test="string-length($str) &gt; 0 and (substring($str, string-length($str)) = '&#x0a;' or substring($str, string-length($str)) = '&#x09;' or substring($str, string-length($str)) = ' ')">
       <!-- recursively call self with the string without the last character -->
       <xsl:call-template name="trim">
         <xsl:with-param name="str">

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 13 08:45:45 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fix for previous change, trim also the tabs (bsc#1197965)
+- 4.5.2
+
+-------------------------------------------------------------------
 Tue Apr 12 13:20:40 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed generating POT files from XML, trim the leading and

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

- Fix up for #164 
- We need to trim also the tabs

## Test

Tested with skelcd-control-openSUSE

```diff
 #: control/control.openSUSE.glade.translations.glade:23
-msgid ""
-"Graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops.\n"
-"\t"
+msgid "Graphical system with GNOME as desktop environment. Suitable for Workstations, Desktops and Laptops."
 msgstr ""
```