### PR TITLE
y2makepot - extract translatable string from Qt designer *.ui files

### DIFF
--- a/build-tools/scripts/Makefile.am
+++ b/build-tools/scripts/Makefile.am
@@ -16,4 +16,4 @@ dist_pkgdata_SCRIPTS = 				\
 # sourced by 'check-textdomain' and 'y2makepot'.
 dist_pkgdata_DATA = gettextdomains
 
-dist_control_DATA = yast_control.its
+dist_control_DATA = yast_control.its qt_ui.its

--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -26,6 +26,7 @@ function get_domains_and_err()
                                 -o -name "*.cpp" \
                                 -o -name "*.erb" \
                                 -o -name "*.glade" \
+                                -o -name "*.ui" \
                                 -o -name "*.ycontrol.xml" \
                                 -o -name "*.ycontrol.xsl" \
                                 -o -name "*.rb"  `
@@ -49,7 +50,7 @@ function get_domains_and_err()
 	# - false matches of comments inside strings
 	# - uncaught _( at line beginning
         MATCH=`perl -n -e 'print "$ARGV: $_" if not /(^\s*\/\/|^\s*#[^\{])/' $F | \
-               perl -n -e 'print "$_" if /<label>|[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
+               perl -n -e 'print "$_" if /<label>|<property\s+name\s*=\s*"text"|[^[:alnum:]_"<](_|__|gettext)\(/../\)/'`
         if [ -n "$MATCH" ]; then
             TR_FILES="$F $TR_FILES" ;
         fi
@@ -63,7 +64,10 @@ function get_domains_and_err()
         D=`egrep '^[[:space:]]*<?[Tt]extdomain>?' $F | head -n 1 | \
             sed 's/^[[:space:]]*<\?[Tt]extdomain[[:space:]]*[=: \
                  '\''"(>]*[[:space:]]*\([-_[:alnum:]]*\).*/\1/'`;
-        if [ -z $D ]; then
+        if [ -z "$D" -a -f TEXTDOMAIN ]; then
+            D=`cat TEXTDOMAIN`
+        fi
+        if [ -z "$D" ]; then
             ERR="$PWD/$F $ERR" ;
         else
             DOMAINS="$D:$F\n$DOMAINS" ;

--- a/build-tools/scripts/gettextdomains
+++ b/build-tools/scripts/gettextdomains
@@ -1,5 +1,18 @@
 ### sourced by 'check-textdomain' and 'y2makepot' ### -*- sh -*-
 
+# Try reading the default text domain from the TEXTDOMAIN file
+#    Argument:  $1 -> directory to search
+#               $F -> the source file
+#    Returns:   $D -> the found text domain
+function default_textdomain()
+{
+    local TD="$1/TEXTDOMAIN"
+    if [ -f "$TD" ]; then
+        echo "File $F: Using default text domain from $TD"
+        D=`cat "$TD"`
+    fi
+}
+
 #
 # get_domains_and_err():
 #     Argument:  $1        -> directory to search
@@ -64,9 +77,21 @@ function get_domains_and_err()
         D=`egrep '^[[:space:]]*<?[Tt]extdomain>?' $F | head -n 1 | \
             sed 's/^[[:space:]]*<\?[Tt]extdomain[[:space:]]*[=: \
                  '\''"(>]*[[:space:]]*\([-_[:alnum:]]*\).*/\1/'`;
-        if [ -z "$D" -a -f TEXTDOMAIN ]; then
-            D=`cat TEXTDOMAIN`
+        # if the text domain is not specified directly in the file then
+        # search for the TEXTDOMAIN file in the source directory or in its parents
+        if [ -z "$D" ]; then
+            DIR=`dirname "$F"`
+            # search in the parent dirs
+            while [ -z "$D" -a "$DIR" != "." ]; do
+                default_textdomain "$DIR"
+                DIR=`dirname "$DIR"`
+            done
+            # search in the top level dir
+            if [ -z "$D" ]; then
+                default_textdomain "$DIR"
+            fi
         fi
+
         if [ -z "$D" ]; then
             ERR="$PWD/$F $ERR" ;
         else

--- a/build-tools/scripts/qt_ui.its
+++ b/build-tools/scripts/qt_ui.its
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!-- Gettext rules for extracting the translatable strings from Qt UI files -->
+<!-- see https://www.gnu.org/software/gettext/manual/html_node/Preparing-ITS-Rules.html -->
+<!-- see https://www.w3.org/TR/its20/ -->
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           xmlns:gt="https://www.gnu.org/s/gettext/ns/its/extensions/1.0"
+           version="2.0">
+
+  <!-- by default all texts in file are translated, disable translations for all nodes below the root <ui> -->
+  <its:translateRule selector="/ui"
+                     translate="no"/>
+  <!-- translate only the texts in the text widget propertes anywhere -->
+  <its:translateRule selector="//widget/property[@name='text']/string"
+                     translate="yes"/>
+  <!-- gettext extension: disable escaping of special XML characters like "&" in the texts -->
+  <gt:escapeRule selector="//widget/property[@name='text']/string" escape="no"/>
+  <!-- gettext extension: trim the leading and trailing whitespace but keep it in the middle -->
+  <gt:preserveSpaceRule selector="//widget/property[@name='text']/string" space="trim"/>
+
+</its:rules>

--- a/build-tools/scripts/y2makepot
+++ b/build-tools/scripts/y2makepot
@@ -26,6 +26,39 @@ if [ -f "$CWD/yast_control.its" ]; then
 else
     CONTROL_ITS="/usr/share/YaST2/control/yast_control.its"
 fi
+if [ -f "$CWD/qt_ui.its" ]; then
+    UI_ITS="$CWD/qt_ui.its"
+else
+    UI_ITS="/usr/share/YaST2/control/qt_ui.its"
+fi
+
+function add_xml_translations()
+{
+    XML_FILES=$1
+    ITS_FILE=$2
+
+    if [ -n "$XML_FILES" ]; then
+        # a POT file was created from other files, we need to do the merge
+        if [ -f "$MODULE.pot" ]; then
+            mv "$MODULE.pot" "$MODULE.other.pot"
+            xgettext_call "$MODULE" "$XML_FILES" "--omit-header --its=$ITS_FILE"
+            if [ -f "$MODULE.pot" ]; then
+                # new file was created, merge the files
+                mv "$MODULE.pot" "$MODULE.xml.pot"
+                echo "Merging the .pot files..."
+                msgcat -o "$MODULE.pot" "$MODULE.other.pot" "$MODULE.xml.pot"
+                rm "$MODULE.xml.pot" "$MODULE.other.pot"
+            else
+                # no new file created, just rename it back
+                mv "$MODULE.other.pot" "$MODULE.pot"
+            fi
+        else
+            # no merge needed, just run gettext and that's it
+            xgettext_call "$MODULE" "$XML_FILES" "--its=$ITS_FILE"
+        fi
+    fi
+
+}
 
 function gettext_call()
 {
@@ -33,6 +66,7 @@ function gettext_call()
     SOURCE_FILES=$2
     SOURCE_RUBY_FILES=$3
     SOURCE_CONTROL_FILES=$4
+    SOURCE_UI_FILES=$5
 
     # remove the old file
     rm -f "$MODULE.pot"
@@ -57,26 +91,8 @@ function gettext_call()
         rxgettext_call "$MODULE" "$SOURCE_RUBY_FILES"
     fi
 
-    if [ -n "$SOURCE_CONTROL_FILES" ]; then
-        # a POT file was created from other files, we need to do the merge
-        if [ -f "$MODULE.pot" ]; then
-            mv "$MODULE.pot" "$MODULE.other.pot"
-            xgettext_call "$MODULE" "$SOURCE_CONTROL_FILES" "--omit-header --its=$CONTROL_ITS"
-            if [ -f "$MODULE.pot" ]; then
-                # new file was created, merge the files
-                mv "$MODULE.pot" "$MODULE.control.pot"
-                echo "Merging the .pot files..."
-                msgcat -o "$MODULE.pot" "$MODULE.other.pot" "$MODULE.control.pot"
-                rm "$MODULE.control.pot" "$MODULE.other.pot"
-            else
-                # no new file created, just rename it back
-                mv "$MODULE.other.pot" "$MODULE.pot"
-            fi
-        else
-            # no merge needed, just run gettext and that's it
-            xgettext_call "$MODULE" "$SOURCE_CONTROL_FILES" "--its=$CONTROL_ITS"
-        fi
-    fi
+    add_xml_translations "$SOURCE_CONTROL_FILES" "$CONTROL_ITS"
+    add_xml_translations "$SOURCE_UI_FILES" "$UI_ITS"
 }
 
 function xgettext_call()
@@ -178,6 +194,7 @@ function generate_potfiles()
     FILES="";
     RUBY_FILES=""
     CONTROL_FILES=""
+    UI_FILES=""
 
     for I in $DOMAINS; do
 	D=${I%%:*} ;
@@ -196,24 +213,24 @@ function generate_potfiles()
         # is it a Ruby file?
         if [[ "$F" =~ \.(erb|rb)$ ]]; then
             RUBY_FILES="$RUBY_FILES $F";
-        else
+        elif [[ "$F" =~ \.glade$ || "$F" =~ \.ycontrol.x[ms]l$ ]]; then
             # TODO: later remove support for the .glade workaround,
             # it is kept just for the backward compatibility
-            if [[ "$F" =~ \.glade$ || "$F" =~ \.ycontrol.x[ms]l$ ]]; then
-                # follow symlinks to have correct file locations
-                if [ -L "$F" ]; then
-                    CONTROL_FILES="$CONTROL_FILES `realpath --relative-to=. \"$F\"`";
-                else
-                    CONTROL_FILES="$CONTROL_FILES $F";
-                fi
+            # follow symlinks to have correct file locations
+            if [ -L "$F" ]; then
+                CONTROL_FILES="$CONTROL_FILES `realpath --relative-to=. \"$F\"`";
             else
-                FILES="$FILES $F" ;
+                CONTROL_FILES="$CONTROL_FILES $F";
             fi
+        elif [[ "$F" =~ \.ui$ ]]; then
+            UI_FILES="$UI_FILES $F"
+        else
+            FILES="$FILES $F" ;
         fi
     done
 
     POT_DST="$POT_DST $MODULE.pot"
-    gettext_call "$MODULE" "$FILES" "$RUBY_FILES" "$CONTROL_FILES"
+    gettext_call "$MODULE" "$FILES" "$RUBY_FILES" "$CONTROL_FILES" "$UI_FILES"
 }
 
 # -- function defininitions -- end ---------------------------------------------

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 16 07:03:10 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Extract the translatable strings also from the Qt *.ui files
+  (bsc#1198097)
+- 4.5.4
+
+-------------------------------------------------------------------
 Thu Apr 21 12:32:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Generate correct source location for POT messages extracted

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -131,6 +131,7 @@ EOF
 %{_datadir}/YaST2/data/devtools/data/rubocop*_yast_style.yml
 %dir %{_datadir}/YaST2/control/
 %{_datadir}/YaST2/control/yast_control.its
+%{_datadir}/YaST2/control/qt_ui.its
 
 %files -n yast2-buildtools
 %{_rpmmacrodir}/macros.yast

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

- https://github.com/libyui/libyui/pull/74
- The texts from Qt `*.ui` files were not included in the POT file

## Solution

- Lets add support Qt designer files, fortunately these are XML so the solution is similar to YaST the control file support.


## Testing

- Tested manually

`y2makepot` finds the texts in libyui-qt:

```pot
#: src/QStyleEditor.ui:26
msgid "&Apply"
msgstr ""

#: src/QStyleEditor.ui:36
msgid "Auto Apply"
msgstr ""

#: src/QStyleEditor.ui:66
msgid "&Load File"
msgstr ""

```
## Links

See also related https://github.com/libyui/libyui/pull/75