### PR TITLE
Rubocop: Avoid adding exec file permissions

### DIFF
--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 10 17:23:47 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Rubocop configuration update: Disable autocorrection for the
+  Lint/ScriptPermission cop or disable it completely.
+  (related to bsc#1209094)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later

--- a/ytools/y2tool/rubocop-0.71.0_yast_style.yml
+++ b/ytools/y2tool/rubocop-0.71.0_yast_style.yml
@@ -195,3 +195,16 @@ Style/TernaryParentheses:
 # And template version is needed if there are more params and it needs some formatting.
 Style/FormatStringToken:
   Enabled: false
+
+# Disable autocorrection for the Lint/ScriptPermission check.
+#
+# When Rubocop finds a shebang ("#!/usr/bin/env ruby") at the beginning of
+# a file it checks for the executable file flag. That makes sense.
+# However, the autocorrection action is to always add the exec flag to the file,
+# but in some situations the correct fix is to actually remove the shebang as it
+# does not make sense. For example the file just defines a class and there is
+# nothing to execute).
+#
+# So require the developer to decide what is the correct fix.
+Lint/ScriptPermission:
+  AutoCorrect: false

--- a/ytools/y2tool/rubocop-1.24.1_yast_style.yml
+++ b/ytools/y2tool/rubocop-1.24.1_yast_style.yml
@@ -234,3 +234,22 @@ Metrics/BlockLength:
   # rspec is known as DSL with big blocks
   Exclude:
     - "**/test/**/*"
+
+# Disable the Lint/ScriptPermission check.
+#
+# When Rubocop finds a shebang ("#!/usr/bin/env ruby") at the beginning of
+# a file it checks for the executable file flag. That makes sense.
+# However, the autocorrection action is to always add the exec flag to the file,
+# but in some situations the correct fix is to actually remove the shebang as it
+# does not make sense (e.g. the file just defines a class and there is nothing
+# to execute).
+#
+# NOTE: Ideally the check should be enabled with autocorrection disabled. But
+# there is a bug in Rubocop 1.24.1 and disabled autocorrection is ignored,
+# it always adds the exec flag. :-(
+#
+# So disable the cop completely and check how it behaves in the future Rubocop
+# versions.
+#
+Lint/ScriptPermission:
+  Enabled: false


### PR DESCRIPTION
- This is related to bug https://bugzilla.suse.com/show_bug.cgi?id=1209094 and pull requests https://github.com/yast/yast-storage-ng/pull/1322, https://github.com/yast/yast-add-on/pull/130 and others.
- The problem is that the Rubocop autocorrection adds the file executable permission to a file which starts with a shebang like `#!/usr/bin/env ruby`. But in some cases the correct fix is actually to remove that shebang, not to fix the file permissions.
- For that reason I wanted to disable the autocorrection so the developers need to fix that manually and need to decide which fix is correct.
- In Rubocop 0.71.0 disabling autocorrection works as expected
- Unfortunately Rubocop 1.24.1 ignores this option and always sets the exec flag. For that reason the check is disabled completely. In the future versions we need to check how it behaves there.
- In Rubocop 0.41.2 (the oldest one we use) the cop is not present so it is not relevant