### PR TITLE
Backport SP6

### DIFF
--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -2,6 +2,7 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- 4.6.2
 
 -------------------------------------------------------------------
 Fri Sep  9 08:21:11 UTC 2022 - Michal Filka <mfilka@suse.com>

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

Rubocop change is not needed in SP6, so lets just skip version and bump to non colliding version.