### PR TITLE
fix: add "which" to the list of dependencies

### DIFF
--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 16 08:11:39 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add "which" to the list of dependencies
+  (gh#yast/yast-devtools#176).
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-devtools.changes
+++ b/package/yast2-devtools.changes
@@ -3,6 +3,7 @@ Mon Sep 16 08:11:39 UTC 2024 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add "which" to the list of dependencies
   (gh#yast/yast-devtools#176).
+- 5.0.1
 
 -------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -33,6 +33,8 @@ BuildRequires:  libxslt
 BuildRequires:  perl-XML-Writer
 BuildRequires:  pkgconfig
 BuildRequires:  sgml-skel
+# required by some scripts like y2makepot
+Requires:       which
 Requires:       yast2-buildtools
 BuildArch:      noarch
 

--- a/package/yast2-devtools.spec
+++ b/package/yast2-devtools.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-devtools
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - Development Tools
 License:        GPL-2.0-or-later


### PR DESCRIPTION
Add `which` to the list of dependencies because it is used by some scripts like `y2makepot`. 