### PR TITLE
Drop usage of %jobs (boo#1237231)

### DIFF
--- a/build-tools/rpm/macros.yast
+++ b/build-tools/rpm/macros.yast
@@ -81,7 +81,7 @@ fi \
     %if %{with yast_run_ci_tests} \
       if [ -f "configure.in.in" -o -f "configure.ac.in" ]; then \
           # TODO: fix the check:ci task to also work with autotools based modules \
-          %{__make} check %{?jobs:-j%jobs}%{?!jobs:%{?_smp_mflags:%_smp_mflags}} \\\
+          %{__make} check %{?_smp_mflags:%_smp_mflags} \\\
               VERBOSE=1 \\\
               Y2DIR="%{buildroot}/%{yast_dir}" \\\
               DESTDIR="%{buildroot}" \
@@ -90,7 +90,7 @@ fi \
     %else \
       if [ ! -f "%{yast_ydatadir}/devtools/NO_MAKE_CHECK" ]; then \
           if [ -f "configure.in.in" -o -f "configure.ac.in" ]; then \
-              %{__make} check %{?jobs:-j%jobs}%{?!jobs:%{?_smp_mflags:%_smp_mflags}} \\\
+              %{__make} check %{?_smp_mflags:%_smp_mflags} \\\
                   VERBOSE=1 \\\
                   Y2DIR="%{buildroot}/%{yast_dir}" \\\
                   DESTDIR="%{buildroot}" \


### PR DESCRIPTION
## Problem

https://bugzilla.opensuse.org/show_bug.cgi?id=1237231

## Solution

Drop usage of %jobs ([boo#1237231](https://bugzilla.opensuse.org/show_bug.cgi?id=1237231))
for reproducible builds.

instead of SUSE-specific %jobs we use %{?_smp_mflags}

_smp_mflags was added into rpm in 2001 via
https://github.com/rpm-software-management/rpm/commit/81de17180f1b870e2bc4ade50814f46ae9d6bf9d

## Testing

- I tested that SLFO/yast2-x11 still builds, still has -j4 in the log and builds reproducibly with this patch


